### PR TITLE
feat(gpu): add ambig gpu configration

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -485,6 +485,43 @@ menu "LVGL configuration"
 			default 8
 			depends on LV_USE_DRAW_VG_LITE
 
+		config LV_USE_DRAW_AMBIQ
+			bool "Use Ambiq GPU"
+			default n
+			select LV_USE_MATRIX
+			select LV_USE_AMBIQ_VG
+
+		config LV_USE_AMBIQ_VG
+			bool "Use Ambiq vector graphics"
+			default n
+			depends on LV_USE_DRAW_AMBIQ
+
+		config LV_AMBIQ_CPU_GPU_ASYNC
+			bool "Make CPU and GPU work in asynchronous mode"
+			default n
+			depends on LV_USE_DRAW_AMBIQ
+
+		config LV_AMBIQ_GPU_POWER_SAVE
+			bool "Enable GPU power management, power off GPU at frame end."
+			default n
+			depends on LV_USE_DRAW_AMBIQ
+
+		config LV_AMBIQ_COMMAND_LIST_SECTOR
+			int "Command list sectors number"
+			default 100
+			depends on LV_USE_DRAW_AMBIQ
+			help
+				The command list is divided into `LV_AMBIQ_COMMAND_LIST_SECTOR` sectors,
+				where each sector has a fixed length of `LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE`
+
+		config LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE
+			int "Command list sector size in bytes"
+			default 1024
+			depends on LV_USE_DRAW_AMBIQ
+			help
+				The command list is divided into `LV_AMBIQ_COMMAND_LIST_SECTOR` sectors,
+				where each sector has a fixed length of `LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE`
+
 		config LV_USE_VECTOR_GRAPHIC
 			bool "Use Vector Graphic APIs"
 			default n

--- a/lv_conf_template.h
+++ b/lv_conf_template.h
@@ -239,6 +239,22 @@
     #endif
 #endif
 
+/* Use ambiq's GPU on Apollo4x or Apollo5x chips. */
+#define LV_USE_DRAW_AMBIQ 0
+
+#if LV_USE_DRAW_AMBIQ
+#define LV_USE_AMBIQ_VG 0
+#define LV_AMBIQ_CPU_GPU_ASYNC 0
+#define LV_AMBIQ_GPU_POWER_SAVE 0
+
+
+/* The command list is divided into `LV_AMBIQ_COMMAND_LIST_SECTOR` sectors,
+ * where each sector has a fixed length of `LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE`.
+ */
+#define LV_AMBIQ_COMMAND_LIST_SECTOR 100
+#define LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE 1024
+#endif
+
 /** Use NXP's VG-Lite GPU on iMX RTxxx platforms. */
 #define LV_USE_DRAW_VGLITE 0
 

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -664,6 +664,58 @@
     #endif
 #endif
 
+/* Use ambiq's GPU on Apollo4x or Apollo5x chips. */
+#ifndef LV_USE_DRAW_AMBIQ
+    #ifdef CONFIG_LV_USE_DRAW_AMBIQ
+        #define LV_USE_DRAW_AMBIQ CONFIG_LV_USE_DRAW_AMBIQ
+    #else
+        #define LV_USE_DRAW_AMBIQ 0
+    #endif
+#endif
+
+#if LV_USE_DRAW_AMBIQ
+#ifndef LV_USE_AMBIQ_VG
+    #ifdef CONFIG_LV_USE_AMBIQ_VG
+        #define LV_USE_AMBIQ_VG CONFIG_LV_USE_AMBIQ_VG
+    #else
+        #define LV_USE_AMBIQ_VG 0
+    #endif
+#endif
+#ifndef LV_AMBIQ_CPU_GPU_ASYNC
+    #ifdef CONFIG_LV_AMBIQ_CPU_GPU_ASYNC
+        #define LV_AMBIQ_CPU_GPU_ASYNC CONFIG_LV_AMBIQ_CPU_GPU_ASYNC
+    #else
+        #define LV_AMBIQ_CPU_GPU_ASYNC 0
+    #endif
+#endif
+#ifndef LV_AMBIQ_GPU_POWER_SAVE
+    #ifdef CONFIG_LV_AMBIQ_GPU_POWER_SAVE
+        #define LV_AMBIQ_GPU_POWER_SAVE CONFIG_LV_AMBIQ_GPU_POWER_SAVE
+    #else
+        #define LV_AMBIQ_GPU_POWER_SAVE 0
+    #endif
+#endif
+
+
+/* The command list is divided into `LV_AMBIQ_COMMAND_LIST_SECTOR` sectors,
+ * where each sector has a fixed length of `LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE`.
+ */
+#ifndef LV_AMBIQ_COMMAND_LIST_SECTOR
+    #ifdef CONFIG_LV_AMBIQ_COMMAND_LIST_SECTOR
+        #define LV_AMBIQ_COMMAND_LIST_SECTOR CONFIG_LV_AMBIQ_COMMAND_LIST_SECTOR
+    #else
+        #define LV_AMBIQ_COMMAND_LIST_SECTOR 100
+    #endif
+#endif
+#ifndef LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE
+    #ifdef CONFIG_LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE
+        #define LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE CONFIG_LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE
+    #else
+        #define LV_AMBIQ_COMMAND_LIST_SECTOR_SIZE 1024
+    #endif
+#endif
+#endif
+
 /** Use NXP's VG-Lite GPU on iMX RTxxx platforms. */
 #ifndef LV_USE_DRAW_VGLITE
     #ifdef CONFIG_LV_USE_DRAW_VGLITE


### PR DESCRIPTION
Adds the necessary configurations for Ambiq Micro's GPU. This includes related settings in `lv_config_template.h`, `Kconfig`, and `lv_conf_internal.h` to enable and configure the Ambiq GPU integration.


